### PR TITLE
Optimize CAMHT training throughput pipeline

### DIFF
--- a/camht/configs/camht.yaml
+++ b/camht/configs/camht.yaml
@@ -42,6 +42,11 @@ train:
   use_pretrain: true
   pretrain_ckpt: checkpoints/timae_encoder.ckpt
   amp_dtype: auto  # auto => bf16(支持时) / 否则 fp16
+  num_workers: 2
+  pin_memory: true
+  persistent_workers: true
+  prefetch_factor: 4
+  prefetch_to_gpu: true
 
 loss:
   diffsort_temperature: 0.1


### PR DESCRIPTION
## Summary
- add a GPU-aware batch container, CUDA prefetcher, and configurable DataLoader builder so training and evaluation can overlap host-to-device work with compute
- teach the training loop to honor gradient accumulation, configurable clip norms, and GPU prefetch for better utilization on large accelerators such as the RTX 5090
- expose dataloader knobs (workers, pinning, GPU prefetch) in the default config to tune memory movement and concurrency

## Testing
- python -m compileall train_camht.py
- python -m compileall camht


------
https://chatgpt.com/codex/tasks/task_e_68d811444cf8832dbc2e3f5be2b30109