### PR TITLE
Optimize training/inference pipeline for RTX 5090

### DIFF
--- a/camht/metrics.py
+++ b/camht/metrics.py
@@ -7,17 +7,37 @@ import torch
 def spearman_rho(preds: torch.Tensor, targets: torch.Tensor) -> torch.Tensor:
     """Compute Spearman rho across last dim and average across batch.
 
+    NaN values in either tensor are ignored per-row so we keep AMP/TensorCore
+    friendly code paths without graph breaks.
+
     Args:
       preds: [B, A]
       targets: [B, A]
     Returns:
       scalar tensor
     """
-    r_t = torch.argsort(torch.argsort(targets, dim=-1), dim=-1).float()
-    r_p = torch.argsort(torch.argsort(preds, dim=-1), dim=-1).float()
-    r_t = r_t - r_t.mean(dim=-1, keepdim=True)
-    r_p = r_p - r_p.mean(dim=-1, keepdim=True)
-    num = (r_p * r_t).mean(dim=-1)
-    den = torch.sqrt((r_p**2).mean(dim=-1) + 1e-8) * torch.sqrt((r_t**2).mean(dim=-1) + 1e-8)
-    return (num / (den + 1e-8)).mean()
+    mask = (~torch.isnan(targets)) & (~torch.isnan(preds))
+    valid_counts = mask.sum(dim=-1, keepdim=True)
+    valid_rows = valid_counts.squeeze(-1) >= 2
+    if not torch.any(valid_rows):
+        return torch.zeros((), device=preds.device, dtype=preds.dtype)
+    fill_value = torch.finfo(preds.dtype).min
+    fill = torch.full_like(preds, fill_value)
+    preds_masked = torch.where(mask, preds, fill)
+    targets_masked = torch.where(mask, targets, fill)
+    r_t = torch.argsort(torch.argsort(targets_masked, dim=-1), dim=-1).float()
+    r_p = torch.argsort(torch.argsort(preds_masked, dim=-1), dim=-1).float()
+    r_t = torch.where(mask, r_t, torch.zeros_like(r_t))
+    r_p = torch.where(mask, r_p, torch.zeros_like(r_p))
+    safe_counts = valid_counts.clamp_min(1).float()
+    r_t = r_t - (r_t.sum(dim=-1, keepdim=True) / safe_counts)
+    r_p = r_p - (r_p.sum(dim=-1, keepdim=True) / safe_counts)
+    num = (r_p * r_t).sum(dim=-1)
+    den = (
+        torch.sqrt((r_p.pow(2).sum(dim=-1)).clamp_min(1e-8))
+        * torch.sqrt((r_t.pow(2).sum(dim=-1)).clamp_min(1e-8))
+    )
+    rho = torch.zeros_like(num)
+    rho[valid_rows] = (num[valid_rows] / (den[valid_rows] + 1e-8))
+    return rho.mean()
 

--- a/infer_submit.py
+++ b/infer_submit.py
@@ -65,8 +65,8 @@ def main():
         for idx in range(num_dates):
             x = feature_tensor[idx].unsqueeze(0).unsqueeze(-1).to(device, non_blocking=True)
             times = time_grid.expand(1, num_assets, args.window, 1)
-            preds = model(x, times)
-            preds_np = [p.squeeze(0).float().cpu().numpy() for p in preds]
+            preds = model(x, times)  # [H, 1, A]
+            preds_np = preds[:, 0].float().cpu().numpy()  # [H, A]
             # 横截面 z-score 稳定秩序
             std_preds = [(p - p.mean()) / (p.std() + 1e-8) for p in preds_np]
             if clip > 0:

--- a/serve_predict.py
+++ b/serve_predict.py
@@ -66,8 +66,8 @@ def predict_endpoint(model: CAMHT, test_hist: pl.DataFrame, label_lag_1: pl.Data
         preds = model(
             latest.unsqueeze(0).unsqueeze(-1).to(device),
             times.to(device),
-        )  # list of 4 [1, A]
-        preds = [p.squeeze(0).float().cpu().numpy() for p in preds]
+        )  # [H, 1, A]
+        preds = preds[:, 0].float().cpu().numpy()
     # Day-level standardization (stabilize ranks)
     preds = [((p - p.mean()) / (p.std() + 1e-8)) for p in preds]
     # optional tanh clip for stability

--- a/train_camht.py
+++ b/train_camht.py
@@ -326,7 +326,7 @@ def evaluate(model, loader, loss_main, loss_stab, device, amp_dtype, amp_enabled
         preds_h0 = preds[0]
         # compute per-day rho within这个 batch（完全向量化处理缺失值）
         target = ys[0]
-        mask = ~torch.isnan(target)
+        mask = (~torch.isnan(target)) & (~torch.isnan(preds_h0))
         valid = mask.sum(dim=-1) >= 2
         fill_value = torch.finfo(preds_h0.dtype).min
         preds_masked = torch.where(mask, preds_h0, torch.full_like(preds_h0, fill_value))

--- a/train_camht.py
+++ b/train_camht.py
@@ -217,7 +217,7 @@ def _make_optimizer(model: nn.Module, *, lr: float, weight_decay: float, device:
             index = device.index if device.index is not None else torch.cuda.current_device()
             major, _ = torch.cuda.get_device_capability(index)
             fused_ok = major >= 8
-        except Exception:  # noqa: BLE001
+        except RuntimeError:  # noqa: BLE001
             fused_ok = False
     if fused_ok:
         extra["fused"] = True


### PR DESCRIPTION
## Summary
- emit fused multi-horizon logits from CAMHT so the training loop can operate on contiguous tensors and avoid Python overhead
- refactor the training pipeline with pinned-memory loaders, fused AdamW detection, and tensorized loss reduction for better RTX 5090 throughput
- harden metrics and inference utilities to ignore NaNs and match the new tensor outputs across offline and serving paths

## Testing
- python -m compileall camht train_camht.py infer_submit.py serve_predict.py

------
https://chatgpt.com/codex/tasks/task_e_68d811444cf8832dbc2e3f5be2b30109