### PR TITLE
Optimize CAMHT training for RTX 5090 performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ CAMHT：Cross-Asset Multi‑Horizon Transformer（竞赛级实现）
 2) 监督训练（CPCV + Sharpe-like 早停）
 - 直接对齐比赛目标：可微 Spearman 主损失 + 稳定性正则（降低日度波动）。
 - 命令：
-  - `python train_camht.py --cfg camht/configs/camht.yaml`
+- `python train_camht.py --cfg camht/configs/camht.yaml`
+- 针对 RTX 5090 32G 进行了专门调优，可直接使用 `python train_camht.py --cfg camht/configs/camht_rtx5090.yaml`
+- DataLoader 通过 `train.train_loader`/`train.eval_loader` 节点配置（工作线程、pin memory、prefetch），可按机器带宽灵活调节。
 - 结果：
   - 每折最佳：`checkpoints/best_fold_{k}.ckpt`
   - 全局最佳（用于 serve）：`checkpoints/best.ckpt`

--- a/camht/configs/camht_rtx5090.yaml
+++ b/camht/configs/camht_rtx5090.yaml
@@ -6,57 +6,57 @@ data:
   test_csv: data/test.csv
   target_pairs_csv: data/target_pairs.csv
   date_column: date_id
-  window: 512
+  window: 640  # leverage 32G VRAM for longer temporal context
   patch_len: 16
   patch_stride: 8
-  features: null  # null => use all numeric cols except date_id
+  features: null
   channels_first: false
   normalize_per_day: true
-  winsorize_p: 0.005
+  winsorize_p: 0.002
 
 model:
-  d_model: 640
-  n_heads: 10
+  d_model: 768
+  n_heads: 12
   dropout: 0.1
-  n_layers_intra: 10
+  n_layers_intra: 12
   n_layers_cross: 6
   activation: gelu
   time2vec_dim: 8
   use_flash_attn: true
   use_compile: true
-  cross_group_size: 16  # Ampere friendly：减小跨资产 token 数，提升吞吐
+  cross_group_size: 16
 
 train:
-  epochs: 30
-  batch_days: 12  # 24GB 3090 可承受更大的日批量
+  epochs: 40
+  batch_days: 18
   grad_accum: 1
-  lr_max: 0.0015
+  lr_max: 0.0012
   weight_decay: 0.05
-  warmup_pct: 0.08
+  warmup_pct: 0.1
   amp: true
-  grad_clip_norm: 1.0
-  checkpoint_dir: checkpoints
+  grad_clip_norm: 0.9
+  checkpoint_dir: checkpoints/rtx5090
   save_every: 1
-  early_stop_patience: 5
-  grad_checkpointing: false
+  early_stop_patience: 6
+  grad_checkpointing: true
   use_pretrain: true
   pretrain_ckpt: checkpoints/timae_encoder.ckpt
-  amp_dtype: auto  # auto => bf16(支持时) / 否则 fp16
+  amp_dtype: bf16
   train_loader:
-    num_workers: 8
+    num_workers: 12
     pin_memory: true
     persistent_workers: true
-    prefetch_factor: 4
+    prefetch_factor: 6
     pin_memory_device: cuda
   eval_loader:
-    num_workers: 4
+    num_workers: 6
     pin_memory: true
     persistent_workers: true
 
 loss:
-  diffsort_temperature: 0.1
-  diffsort_regularization: none  # sinkhorn|l2|none (torchsort)
-  stability_lambda: 0.2
+  diffsort_temperature: 0.08
+  diffsort_regularization: none
+  stability_lambda: 0.25
 
 cv:
   n_splits: 5
@@ -66,20 +66,20 @@ cv:
   use_cpcv: true
 
 inference:
-  snapshot: checkpoints/best.ckpt
+  snapshot: checkpoints/rtx5090/best.ckpt
   tanh_clip: 0.0
 
 pretrain:
-  epochs: 10
+  epochs: 12
   lr: 0.001
   weight_decay: 0.05
-  mask_ratio: 0.5
-  batch_days: 16
-  window: 512
+  mask_ratio: 0.45
+  batch_days: 18
+  window: 640
   patch_len: 16
   patch_stride: 8
   time2vec_dim: 8
 
 logging:
-  log_dir: runs/camht
-  csv_log: runs/metrics.csv
+  log_dir: runs/camht_rtx5090
+  csv_log: runs/metrics_rtx5090.csv

--- a/camht/losses.py
+++ b/camht/losses.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-from typing import Iterable, Optional
+from typing import Optional
 
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 
 try:
     import torchsort  # type: ignore
@@ -13,32 +12,39 @@ except Exception:  # noqa: BLE001
 
 
 class DiffSpearmanLoss(nn.Module):
-    """Differentiable Spearman via torchsort (SoftRank).
-
-    If torchsort is unavailable, fallback to negative Spearman computed with rankdata+pearson
-    which is not strictly differentiable; warn user.
-    """
+    """Differentiable Spearman via torchsort (SoftRank) with optional row weights."""
 
     def __init__(self, temperature: float = 0.1, regularization: str = "none") -> None:
         super().__init__()
         self.temperature = temperature
         self.regularization = regularization
 
-    def forward(self, preds: torch.Tensor, targets: torch.Tensor) -> torch.Tensor:
-        """Compute 1 - Spearman(preds, targets) across the last dimension.
+    def forward(
+        self,
+        preds: torch.Tensor,
+        targets: torch.Tensor,
+        *,
+        row_weights: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if preds.ndim > 2:
+            preds = preds.reshape(-1, preds.shape[-1])
+            targets = targets.reshape(-1, targets.shape[-1])
+            if row_weights is not None:
+                row_weights = row_weights.reshape(-1)
+        return self._loss_2d(preds, targets, row_weights)
 
-        Args:
-            preds: [B, A]
-            targets: [B, A]
-        """
-        # Row-wise masking of NaNs in targets (and corresponding preds)
-        # 使用布尔 mask 一次性筛掉缺失值，避免 Python 循环导致的图中断
+    def _loss_2d(
+        self,
+        preds: torch.Tensor,
+        targets: torch.Tensor,
+        row_weights: torch.Tensor | None = None,
+    ) -> torch.Tensor:
         mask = ~torch.isnan(targets)
         mask_f = mask.to(preds.dtype)
-        valid_counts = mask.sum(dim=-1, keepdim=True)
-        valid_rows = valid_counts.squeeze(-1) >= 2
+        valid_counts = mask.sum(dim=-1)
+        valid_rows = valid_counts >= 2
         if valid_rows.sum() == 0:
-            return torch.zeros((), device=preds.device)
+            return torch.zeros((), device=preds.device, dtype=preds.dtype)
 
         fill_value = torch.finfo(preds.dtype).min
         fill = torch.full_like(preds, fill_value)
@@ -46,31 +52,49 @@ class DiffSpearmanLoss(nn.Module):
         t_masked = torch.where(mask, targets, fill)
 
         if torchsort is not None:
-            sr_p = torchsort.soft_rank(p_masked, regularization=self.regularization, temperature=self.temperature)
-            sr_t = torchsort.soft_rank(t_masked, regularization=self.regularization, temperature=self.temperature)
+            sr_p = torchsort.soft_rank(
+                p_masked,
+                regularization=self.regularization,
+                temperature=self.temperature,
+            )
+            sr_t = torchsort.soft_rank(
+                t_masked,
+                regularization=self.regularization,
+                temperature=self.temperature,
+            )
         else:
-            sr_p = torch.argsort(torch.argsort(p_masked, dim=-1), dim=-1).float()
-            sr_t = torch.argsort(torch.argsort(t_masked, dim=-1), dim=-1).float()
+            sr_p = torch.argsort(torch.argsort(p_masked, dim=-1), dim=-1).to(preds.dtype)
+            sr_t = torch.argsort(torch.argsort(t_masked, dim=-1), dim=-1).to(preds.dtype)
 
-        invalid_counts = (~mask).sum(dim=-1, keepdim=True).float()
+        invalid_counts = (~mask).sum(dim=-1, keepdim=True).to(preds.dtype)
         sr_p = sr_p - invalid_counts
         sr_t = sr_t - invalid_counts
 
-        sr_p = torch.where(mask, sr_p, torch.zeros_like(sr_p)).float()
-        sr_t = torch.where(mask, sr_t, torch.zeros_like(sr_t)).float()
+        sr_p = torch.where(mask, sr_p, torch.zeros_like(sr_p))
+        sr_t = torch.where(mask, sr_t, torch.zeros_like(sr_t))
 
-        safe_counts = valid_counts.clamp_min(1).float()
-        mean_p = (sr_p * mask_f).sum(dim=-1, keepdim=True) / safe_counts
-        mean_t = (sr_t * mask_f).sum(dim=-1, keepdim=True) / safe_counts
-        xp = (sr_p - mean_p) * mask_f
-        xt = (sr_t - mean_t) * mask_f
-        eps = 1e-8
-        cov = (xp * xt).sum(dim=-1) / safe_counts.squeeze(-1)
-        var_p = (xp.pow(2).sum(dim=-1) / safe_counts.squeeze(-1)).clamp_min(eps)
-        var_t = (xt.pow(2).sum(dim=-1) / safe_counts.squeeze(-1)).clamp_min(eps)
+        safe_counts = valid_counts.clamp_min(1).to(preds.dtype)
+        mean_p = (sr_p * mask_f).sum(dim=-1) / safe_counts
+        mean_t = (sr_t * mask_f).sum(dim=-1) / safe_counts
+        xp = (sr_p - mean_p.unsqueeze(-1)) * mask_f
+        xt = (sr_t - mean_t.unsqueeze(-1)) * mask_f
+        eps = torch.tensor(1e-8, dtype=preds.dtype, device=preds.device)
+        cov = (xp * xt).sum(dim=-1) / safe_counts
+        var_p = (xp.pow(2).sum(dim=-1) / safe_counts).clamp_min(eps)
+        var_t = (xt.pow(2).sum(dim=-1) / safe_counts).clamp_min(eps)
         rho = cov / (var_p.sqrt() * var_t.sqrt() + eps)
         rho = torch.where(valid_rows, rho, torch.zeros_like(rho))
-        return (1.0 - rho).mean()
+
+        if row_weights is not None:
+            weights = row_weights.to(device=preds.device, dtype=preds.dtype)
+            weights = torch.where(valid_rows, weights, torch.zeros_like(weights))
+            weight_sum = weights.sum()
+            if weight_sum <= 0:
+                return torch.zeros((), device=preds.device, dtype=preds.dtype)
+            loss = (1.0 - rho) * weights
+            return loss.sum() / weight_sum
+
+        return (1.0 - rho[valid_rows]).mean()
 
 
 class StabilityRegularizer(nn.Module):
@@ -86,7 +110,7 @@ class StabilityRegularizer(nn.Module):
     def forward(self, preds: torch.Tensor, targets: Optional[torch.Tensor] = None) -> torch.Tensor:
         # preds: [B, A] for a given horizon, where B groups consecutive days
         if preds.shape[0] < 2 or self.weight <= 0.0:
-            return torch.tensor(0.0, device=preds.device)
+            return preds.new_zeros(())
         # 直接用张量差分并结合掩码，彻底消除逐样本 for 循环
         diff = preds[1:] - preds[:-1]
         if targets is not None:
@@ -97,5 +121,5 @@ class StabilityRegularizer(nn.Module):
         else:
             penalty = diff.pow(2).mean(dim=-1)
         if penalty.numel() == 0:
-            return torch.zeros((), device=preds.device)
+            return preds.new_zeros(())
         return self.weight * penalty.mean()

--- a/camht/metrics.py
+++ b/camht/metrics.py
@@ -4,20 +4,70 @@ import torch
 
 
 @torch.no_grad()
-def spearman_rho(preds: torch.Tensor, targets: torch.Tensor) -> torch.Tensor:
-    """Compute Spearman rho across last dim and average across batch.
+def masked_spearman(
+    preds: torch.Tensor,
+    targets: torch.Tensor,
+    mask: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Row-wise Spearman rho under an optional validity mask.
 
     Args:
-      preds: [B, A]
-      targets: [B, A]
+        preds: [..., A]
+        targets: [..., A]
+        mask: [..., A] boolean mask where True marks valid entries. If None, derive from
+            ~isnan(targets).
+
     Returns:
-      scalar tensor
+        rho: tensor of shape preds.shape[:-1] with per-row rho (invalid rows filled with 0)
+        valid_rows: boolean tensor indicating rows with >=2 valid entries
     """
-    r_t = torch.argsort(torch.argsort(targets, dim=-1), dim=-1).float()
-    r_p = torch.argsort(torch.argsort(preds, dim=-1), dim=-1).float()
-    r_t = r_t - r_t.mean(dim=-1, keepdim=True)
-    r_p = r_p - r_p.mean(dim=-1, keepdim=True)
-    num = (r_p * r_t).mean(dim=-1)
-    den = torch.sqrt((r_p**2).mean(dim=-1) + 1e-8) * torch.sqrt((r_t**2).mean(dim=-1) + 1e-8)
-    return (num / (den + 1e-8)).mean()
+
+    if mask is None:
+        mask = ~torch.isnan(targets)
+    mask_f = mask.to(dtype=preds.dtype)
+    valid_counts = mask.sum(dim=-1)
+    valid_rows = valid_counts >= 2
+
+    fill_value = torch.finfo(preds.dtype).min
+    fill = torch.full_like(preds, fill_value)
+    preds_masked = torch.where(mask, preds, fill)
+    targets_masked = torch.where(mask, targets, fill)
+
+    rank_preds = torch.argsort(torch.argsort(preds_masked, dim=-1), dim=-1).to(preds.dtype)
+    rank_targets = torch.argsort(torch.argsort(targets_masked, dim=-1), dim=-1).to(preds.dtype)
+
+    rank_preds = torch.where(mask, rank_preds, torch.zeros_like(rank_preds))
+    rank_targets = torch.where(mask, rank_targets, torch.zeros_like(rank_targets))
+
+    safe_counts = valid_counts.clamp_min(1).to(dtype=preds.dtype)
+    mean_preds = (rank_preds * mask_f).sum(dim=-1, keepdim=True) / safe_counts.unsqueeze(-1)
+    mean_targets = (rank_targets * mask_f).sum(dim=-1, keepdim=True) / safe_counts.unsqueeze(-1)
+
+    xc = (rank_preds - mean_preds) * mask_f
+    yc = (rank_targets - mean_targets) * mask_f
+    eps = torch.tensor(1e-8, dtype=preds.dtype, device=preds.device)
+    cov = (xc * yc).sum(dim=-1) / safe_counts
+    var_p = (xc.pow(2).sum(dim=-1) / safe_counts).clamp_min(eps)
+    var_t = (yc.pow(2).sum(dim=-1) / safe_counts).clamp_min(eps)
+    rho = cov / (var_p.sqrt() * var_t.sqrt() + eps)
+    rho = torch.where(valid_rows, rho, torch.zeros_like(rho))
+    return rho, valid_rows
+
+
+@torch.no_grad()
+def spearman_rho(
+    preds: torch.Tensor,
+    targets: torch.Tensor,
+    mask: torch.Tensor | None = None,
+    *,
+    reduce: bool = True,
+) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+    """Spearman rho averaged across rows with NaN-aware masking."""
+
+    rho, valid_rows = masked_spearman(preds, targets, mask)
+    if not reduce:
+        return rho, valid_rows
+    if valid_rows.any():
+        return rho[valid_rows].mean()
+    return torch.zeros((), device=preds.device, dtype=preds.dtype)
 


### PR DESCRIPTION
## Summary
- streamline the window dataset to emit batched targets and masks, add high-throughput DataLoader builders, and upgrade the training loop with gradient accumulation, weighted horizon losses, and fused AdamW for RTX 5090
- extend DiffSpearmanLoss and masked Spearman metrics to support row weighting and reusable masking while hardening the stability regularizer
- expose loader tunables in the default config, ship an RTX5090-32G preset, and document the new workflow in the README

## Testing
- python -m compileall train_camht.py camht

------
https://chatgpt.com/codex/tasks/task_e_68d811444cf8832dbc2e3f5be2b30109